### PR TITLE
Report code coverage change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         run: make test
 
       - name: Report code coverage
-        uses: zgosalvez/github-actions-report-lcov@v4
+        uses: xarantolus/github-actions-report-lcov@v5
         with:
           coverage-files: lcov.info
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This uses my [own fork of the coverage action](https://github.com/xarantolus/github-actions-report-lcov) to comment not only the test coverage, but also the change in test coverage. Note that this will only start working once this change has been merged into the main branch.