### PR TITLE
Replace invalid `cargo::info=` with `cargo::warning=`

### DIFF
--- a/machine/arm/build.rs
+++ b/machine/arm/build.rs
@@ -188,7 +188,7 @@ fn forward_fpu_config(config: &mut Config) -> Result<()> {
     config.asmflag(format!("-mfpu={fpu_type}"));
     config.asmflag(format!("-mfloat-abi={float_abi}"));
 
-    println!("cargo::info=ARM FPU: {fpu_type}, Float ABI: {float_abi}");
+    println!("cargo::warning=ARM FPU: {fpu_type}, Float ABI: {float_abi}");
 
     Ok(())
 }


### PR DESCRIPTION
This happens when building with FPU enabled.

`cargo::info=` is not a valid build-script directive and aborts the build on cargo 1.94. Use `cargo::warning=` to match the convention already used elsewhere in this same build script for informational output.

See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script