### PR TITLE
STM32 HAL: only copy to out dir if linker script changes

### DIFF
--- a/machine/arm/st/stm32l4/CMakeLists.txt
+++ b/machine/arm/st/stm32l4/CMakeLists.txt
@@ -48,7 +48,11 @@ add_custom_command(
   COMMAND ${CMAKE_C_COMPILER} -E -P -x c
           ${CONFIG_DEFINES}
           ${LINKER_SCRIPT_IN}
-          -o ${LINKER_SCRIPT_OUT}
+          -o ${LINKER_SCRIPT_OUT}.tmp
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+          ${LINKER_SCRIPT_OUT}.tmp
+          ${LINKER_SCRIPT_OUT}
+  COMMAND ${CMAKE_COMMAND} -E remove ${LINKER_SCRIPT_OUT}.tmp
   DEPENDS ${LINKER_SCRIPT_IN} ${DEPS_FILE}
   COMMENT "Generating link.ld"
   VERBATIM


### PR DESCRIPTION
Previously, the hal-arm would regenerate every time due to the mtime of the build script changing. Now we only copy it if it has changes.

I tested this by changing OSIRIS_TUNING_ENABLEFPU, which propagates to this script. Only the first time after a change I see a ~2 second run of the hal-arm (build) script, and afterwards it only rebuilds when we change the variable again.