### PR TITLE
Do not pass additional softfp argument to ARM build

### DIFF
--- a/machine/arm/cmake/toolchain.cmake
+++ b/machine/arm/cmake/toolchain.cmake
@@ -10,8 +10,6 @@ set(CMAKE_OBJCOPY ${TOOLCHAIN_PREFIX}-objcopy)
 set(CMAKE_NM ${TOOLCHAIN_PREFIX}-nm)
 set(CMAKE_SIZE ${TOOLCHAIN_PREFIX}-size)
 
-add_compile_options(-mfloat-abi=softfp)
-
 # Implement syscalls as stubs, as we are on bare metal.
 set(CMAKE_EXE_LINKER_FLAGS "--specs=nosys.specs" CACHE INTERNAL "")
 


### PR DESCRIPTION
Sometimes I get a linker error like this when FPU is enabled:

```
  CMake Error at /usr/share/cmake/Modules/CMakeTestCCompiler.cmake:67 (message):
    The C compiler

      "/usr/bin/arm-none-eabi-gcc"

    is not able to compile a simple test program.

    It fails with the following output:

      Change Dir: '/workspaces/osiris/target/thumbv7em-none-eabihf/debug/build/hal-arm-be027c16443366c6/out/build/CMakeFiles/CMakeScratch/TryCompile-cTc8um'
      
      Run Build Command(s): /usr/bin/ninja-build -v cmTC_b3a5e
      [1/2] /usr/bin/arm-none-eabi-gcc   -DSTM32L4R5xx -DSTM32L4R5 -DSTM32L4xx -DSTM32L4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard -ffunction-sections -fdata-sections -mfloat-abi=hard -mthumb -march=armv7e-m -mfpu=fpv4-sp-d16 -w  -mfloat-abi=softfp -o CMakeFiles/cmTC_b3a5e.dir/testCCompiler.c.obj -c /workspaces/osiris/target/thumbv7em-none-eabihf/debug/build/hal-arm-be027c16443366c6/out/build/CMakeFiles/CMakeScratch/TryCompile-cTc8um/testCCompiler.c
      [2/2] : && /usr/bin/arm-none-eabi-gcc -DSTM32L4R5xx -DSTM32L4R5 -DSTM32L4xx -DSTM32L4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard -ffunction-sections -fdata-sections -mfloat-abi=hard -mthumb -march=armv7e-m -mfpu=fpv4-sp-d16 -w --specs=nosys.specs CMakeFiles/cmTC_b3a5e.dir/testCCompiler.c.obj -o cmTC_b3a5e   && :
      FAILED: [code=1] cmTC_b3a5e 
      : && /usr/bin/arm-none-eabi-gcc -DSTM32L4R5xx -DSTM32L4R5 -DSTM32L4xx -DSTM32L4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard -ffunction-sections -fdata-sections -mfloat-abi=hard -mthumb -march=armv7e-m -mfpu=fpv4-sp-d16 -w --specs=nosys.specs CMakeFiles/cmTC_b3a5e.dir/testCCompiler.c.obj -o cmTC_b3a5e   && :
      /usr/lib/gcc/arm-none-eabi/15.2.0/../../../../arm-none-eabi/bin/ld: /usr/lib/gcc/arm-none-eabi/15.2.0/../../../../arm-none-eabi/lib/thumb/v7e-m+fp/hard/libc.a(libc_a-closer.o): in function `_close_r':
      /builddir/build/BUILD/arm-none-eabi-newlib-4.5.0.20241231-build/newlib-4.5.0.20241231/build-newlib/arm-none-eabi/thumb/v7e-m+fp/hard/newlib/../../../../../../newlib/libc/reent/closer.c:47:(.text._close_r+0xc): warning: _close is not implemented and will always fail
      /usr/lib/gcc/arm-none-eabi/15.2.0/../../../../arm-none-eabi/bin/ld: /usr/lib/gcc/arm-none-eabi/15.2.0/../../../../arm-none-eabi/lib/thumb/v7e-m+fp/hard/libc.a(libc_a-lseekr.o): in function `_lseek_r':
      /builddir/build/BUILD/arm-none-eabi-newlib-4.5.0.20241231-build/newlib-4.5.0.20241231/build-newlib/arm-none-eabi/thumb/v7e-m+fp/hard/newlib/../../../../../../newlib/libc/reent/lseekr.c:49:(.text._lseek_r+0x12): warning: _lseek is not implemented and will always fail
      /usr/lib/gcc/arm-none-eabi/15.2.0/../../../../arm-none-eabi/bin/ld: /usr/lib/gcc/arm-none-eabi/15.2.0/../../../../arm-none-eabi/lib/thumb/v7e-m+fp/hard/libc.a(libc_a-readr.o): in function `_read_r':
      /builddir/build/BUILD/arm-none-eabi-newlib-4.5.0.20241231-build/newlib-4.5.0.20241231/build-newlib/arm-none-eabi/thumb/v7e-m+fp/hard/newlib/../../../../../../newlib/libc/reent/readr.c:49:(.text._read_r+0x12): warning: _read is not implemented and will always fail
      /usr/lib/gcc/arm-none-eabi/15.2.0/../../../../arm-none-eabi/bin/ld: /usr/lib/gcc/arm-none-eabi/15.2.0/../../../../arm-none-eabi/lib/thumb/v7e-m+fp/hard/libc.a(libc_a-writer.o): in function `_write_r':
      /builddir/build/BUILD/arm-none-eabi-newlib-4.5.0.20241231-build/newlib-4.5.0.20241231/build-newlib/arm-none-eabi/thumb/v7e-m+fp/hard/newlib/../../../../../../newlib/libc/reent/writer.c:49:(.text._write_r+0x12): warning: _write is not implemented and will always fail
      /usr/lib/gcc/arm-none-eabi/15.2.0/../../../../arm-none-eabi/bin/ld: error: cmTC_b3a5e uses VFP register arguments, CMakeFiles/cmTC_b3a5e.dir/testCCompiler.c.obj does not
      /usr/lib/gcc/arm-none-eabi/15.2.0/../../../../arm-none-eabi/bin/ld: failed to merge target specific data of file CMakeFiles/cmTC_b3a5e.dir/testCCompiler.c.obj
      collect2: error: ld returned 1 exit status
      ninja: build stopped: subcommand failed.
```

As you can see here:

```
-mfloat-abi=hard -mthumb -march=armv7e-m -mfpu=fpv4-sp-d16 -w  -mfloat-abi=softfp
```

We are passing multiple float-abi options, with the last one being the one from this file, which then overrides the flag set in the build.rs file of `machine/arm`.