### PR TITLE
CI: build with all features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         run: just config load ${{ matrix.config.name }} --no-confirm
 
       - name: Run task
-        run: just ${{ matrix.task }}
+        run: just ${{ matrix.task }} --all-features
 
       - name: Upload docs artifact
         if: matrix.task == 'docs'


### PR DESCRIPTION
It looks like quite some errors slipped through because we didn't enable all features when building / testing, this PR fixes and prevents that in the future.